### PR TITLE
Accelerate world split

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ rasterstats
 osmium==3.2.0
 pyrosm
 geopy               # geocoding client
-rtree==0.9.7        # spatial indexing
 
 # OPSIS
 nismod-snail==0.2.1

--- a/workflow/scripts/process/world_split.py
+++ b/workflow/scripts/process/world_split.py
@@ -41,18 +41,9 @@ if __name__ == "__main__":
     )
 
     print("loading country layer=0")
-    with fiona.open(
-        os.path.join(output_dir, "input", "admin-boundaries", f"gadm36_levels.gpkg"),
-        "r",
-        layer=0,
-    ) as src_code:
-        code_geoms = []
-        code_GIDs = []
-        for feature in src_code:
-            code_geoms.append(shape(feature["geometry"]))
-            code_GIDs.append(feature["properties"]["GID_0"])
-        print("create dataframe")
-        countries = gpd.GeoDataFrame({"geometry": code_geoms, "code": code_GIDs})
+    admin_data_path = os.path.join(output_dir, "input", "admin-boundaries", "gadm36_levels.gpkg")
+    countries = gpd.read_file(admin_data_path, layer=0).drop(["NAME_0"], axis="columns")
+    countries = countries.rename({"GID_0": "code"}, axis="columns")
 
     print(f"country length: {len(countries)}")
     print("Find countries intersecting with each grid cell...")


### PR DESCRIPTION
The `workflow/scripts/process/world_split.py` script takes a box size in degrees, creates a grid and intersects this grid with a geopackage of country geometries to find which countries lie in each grid cell. 

The previous implementation was very slow and took approximately an hour and a half to run for a 5 degree grid.

Now changed to use a shapely STRtree (spatial index) to accelerate the intersection. It should take a minute or two now, and most of this time is writing out geopackage files for each box.

To run:
```
snakemake --cores 1 results/power_processed/world_boxes_metadata.txt
``` 