### PR TITLE
Power intersection failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # geospatial
-geopandas==0.10.2
+geopandas==0.11.0
 shapely>=1.8.2
 pyproj>=3.3.1
 rasterio

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ geopy               # geocoding client
 
 # OPSIS
 nismod-snail==0.2.1
-snkit
+-e git+https://github.com/tomalrussell/snkit.git@master#egg=snkit
 
 # workflow
 snakemake==6.15.1

--- a/workflow/scripts/process/process_power_4_network.py
+++ b/workflow/scripts/process/process_power_4_network.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     # Combine to nodes
     # print("combining sources and sinks")
-    nodes = plants.append(targets).reset_index(drop=True)  # sources and targets located
+    nodes = gpd.GeoDataFrame(pd.concat([plants, targets], ignore_index=True), crs=plants.crs)
     # timer(start)
 
     # Edges


### PR DESCRIPTION
Should address #77, where the `intersect_all` rule was failing in three cases:
- `edges_affected_frag` in `intersect_4_gdploss.py` was an empty `GeoDataFrame`. Geopandas would error rather than write the empty file. Change: upgrade geopandas from 0.10.2 -> 0.11. I had a look through the [changelog](https://github.com/geopandas/geopandas/blob/main/CHANGELOG.md) and did a search for deprecated functions in the open-gira workflow scripts, but didn't find anything obvious that would break as a result.
- `snkit.network.link_nodes_to_nearest_edge` was being passed a `DataFrame` rather than `GeoDataFrame`. Change: make the nodes in the intersection script as a `GeoDataFrame`.
- `snkit.network.nearest` was being passed a `DataFrame` rather than a `GeoDataFrame`, ultimately from the old implementation of `snkit.network.split_multilinestring`. Change: Update snkit. I have changed the snkit requirements entry to the HEAD of the master branch. Alternatively could you release a new version, @tomalrussell?

I will leave the power workflow alone and start on with implementing direct damages for flooding, but I would really like to run this successfully at least once first...