### PR TITLE
discard single node ways

### DIFF
--- a/workflow/scripts/osm_to_pq.py
+++ b/workflow/scripts/osm_to_pq.py
@@ -65,6 +65,10 @@ class WaySlicer(osmium.SimpleHandler):
         self.tags_to_preserve = tags_to_preserve
 
     def way(self, w):
+        if len(w.nodes) < 2:
+            # not enough points in this way to create a linestring, short circuit
+            return
+
         # Prepare information for all segments
         base_input = {}
         for k in self.tags_to_preserve:


### PR DESCRIPTION
Fix for #79, where ways with a single node were raising errors in the `osm_to_pq.py` script as shapely was rightly complaining that a `LineString` must have a minimum of 2 coordinate pairs.