### PR TITLE
add slice count as param, triggers rerun on change

### DIFF
--- a/workflow/rules/preprocess/create_bbox_extracts.smk
+++ b/workflow/rules/preprocess/create_bbox_extracts.smk
@@ -3,6 +3,10 @@ rule create_bbox_extracts:
     conda: "../../../environment.yml"
     input:
         "{OUTPUT_DIR}/json/{DATASET}.json",
+    params:
+        # include slice_count as a param (despite not using elsewhere in the
+        # rule) to trigger re-runs on change to this configuration option
+        slice_count = config["slice_count"]
     output:
         # double curly braces allow us to expand but keep wildcards!
         expand(


### PR DESCRIPTION
Previously, had to remember to wipe intermediate files (json, slices, etc) if user changed `slice_count` and attempted to rerun.