### PR TITLE
bugfix/parameterised_thread_count

### DIFF
--- a/workflow/rules/exposure/wind_fields.smk
+++ b/workflow/rules/exposure/wind_fields.smk
@@ -201,6 +201,8 @@ rule estimate_wind_fields:
     Optionally plot wind fields and save to disk
     """
     input:
+        # `threads_for_country` will fail unless this CSV is present when resources are set
+        country_target_count=country_target_count_path,
         storm_file=storm_tracks_by_country,
         wind_grid="{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/storms/wind_grid.tiff",
         downscaling_factors=rules.create_downscaling_factors.output.downscale_factors,


### PR DESCRIPTION
to dynamically set the number of threads (and amount of memory) for certain rules (create_power_network and estimate_wind_fields) we use a dynamically generated CSV file with the number of targets in each country

this file must be present for rules to allocate resources

use the checkpoint lookup in an input function to guarantee its presence

previously, we had removed the checkpoint lookup from the `threads_for_country` function as per the docs, but this does not seem to work (snakemake error on comparison of thread count integer and 'TBDString')

maybe this whole scaling resources is too much complexity, but trying to run a global analysis without it is also inefficient at the aforementioned rules...