### PR TITLE
Pin xarray to previous release, preventing concatenation error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -51,4 +51,6 @@ dependencies:
   # https://github.com/snakemake/snakemake/issues/1891
   - tqdm==4.62.3        # progress bars
   - wget                # file downloader
+  # pin as 2023.11.0 will duplicate/nisname coords when concatenating
+  - xarray==2023.10.1   # named n-dimensional arrays
   - zenodo_get          # data download client


### PR DESCRIPTION
With xarray==2023.11.0, concat_wind_over_sample.py will create the following file with two "SP_8_8513_1" event_ids rather than one, despite only a single existing in the input files to concatenate: results/power/by_country/NCL/storms/STORM-constant/max_wind_field.nc