### PR TITLE
Mark per-sample wind fields as temporary

### DIFF
--- a/workflow/rules/exposure/wind_fields.smk
+++ b/workflow/rules/exposure/wind_fields.smk
@@ -218,7 +218,7 @@ rule estimate_wind_fields:
     output:
         # enable or disable plotting in the config file
         plot_dir=directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/storms/{STORM_SET}/{SAMPLE}/plots/"),
-        wind_speeds="{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/storms/{STORM_SET}/{SAMPLE}/max_wind_field.nc",
+        wind_speeds=temp("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/storms/{STORM_SET}/{SAMPLE}/max_wind_field.nc"),
     script:
         "../../scripts/intersect/estimate_wind_fields.py"
 


### PR DESCRIPTION
We concatenate these across sample for later use. Discard the per-sample files to save disk.