### PR TITLE
Protect outputs and keep intermediates

### DIFF
--- a/workflow/rules/exposure/electricity_grid/disruption.smk
+++ b/workflow/rules/exposure/electricity_grid/disruption.smk
@@ -101,7 +101,7 @@ rule aggregate_per_event_disruption_across_samples:
     input:
         per_sample = disruption_per_event_sample_files,
     output:
-        all_samples = "{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/pop_affected_by_event.pq",
+        all_samples = protected("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/pop_affected_by_event.pq"),
     run:
         import pandas as pd
 
@@ -134,7 +134,7 @@ rule aggregate_per_target_disruption_across_samples:
     input:
         per_sample = disruption_per_target_sample_files,
     output:
-        all_samples = "{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/pop_affected_by_target.pq",
+        all_samples = protected("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/pop_affected_by_target.pq"),
     run:
         import pandas as pd
 

--- a/workflow/rules/exposure/electricity_grid/exposure.smk
+++ b/workflow/rules/exposure/electricity_grid/exposure.smk
@@ -48,7 +48,7 @@ rule aggregate_per_event_exposure_across_samples:
     input:
         per_sample = exposure_per_event_sample_files,
     output:
-        all_samples = "{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/length_m_by_event.pq",
+        all_samples = protected("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/length_m_by_event.pq"),
     run:
         import pandas as pd
 
@@ -81,7 +81,7 @@ rule aggregate_per_edge_exposure_across_samples:
     input:
         per_sample = exposure_per_edge_sample_files,
     output:
-        all_samples = "{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/length_m_by_edge.pq",
+        all_samples = protected("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/length_m_by_edge.pq"),
     run:
         import pandas as pd
 

--- a/workflow/rules/exposure/electricity_grid/intersection.smk
+++ b/workflow/rules/exposure/electricity_grid/intersection.smk
@@ -142,8 +142,8 @@ rule electricity_grid_damages:
     resources:
         mem_mb = lambda wildcards: threads_for_country(wildcards) * 1_024 * 2.5
     output:
-        exposure = temp(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/{SAMPLE}/")),
-        disruption = temp(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/{SAMPLE}/")),
+        exposure = protected(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/{SAMPLE}/")),
+        disruption = protected(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/{SAMPLE}/")):we,
     script:
         "../../../scripts/intersect/grid_disruption.py"
 

--- a/workflow/rules/exposure/electricity_grid/intersection.smk
+++ b/workflow/rules/exposure/electricity_grid/intersection.smk
@@ -143,7 +143,7 @@ rule electricity_grid_damages:
         mem_mb = lambda wildcards: threads_for_country(wildcards) * 1_024 * 2.5
     output:
         exposure = protected(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/exposure/{STORM_SET}/{SAMPLE}/")),
-        disruption = protected(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/{SAMPLE}/")):we,
+        disruption = protected(directory("{OUTPUT_DIR}/power/by_country/{COUNTRY_ISO_A3}/disruption/{STORM_SET}/{SAMPLE}/")),
     script:
         "../../../scripts/intersect/grid_disruption.py"
 


### PR DESCRIPTION
Do not throw away per-storm netCDF files. Mark them and per-country summaries as 'protected' to partially guard against accidental deletion.