### PR TITLE
Discard duplicate tracks

### DIFF
--- a/workflow/rules/download/STORM.smk
+++ b/workflow/rules/download/STORM.smk
@@ -7,6 +7,7 @@ Reference
 https://data.4tu.nl/articles/dataset/STORM_tropical_cyclone_wind_speed_return_periods/12705164/3
 https://data.4tu.nl/articles/dataset/STORM_climate_change_tropical_cyclone_wind_speed_return_periods/14510817/3
 https://data.4tu.nl/articles/dataset/STORM_IBTrACS_present_climate_synthetic_tropical_cyclone_tracks/12706085/4
+https://data.4tu.nl/articles/dataset/STORM_Climate_Change_synthetic_tropical_cyclone_tracks/14237678
 """
 
 

--- a/workflow/rules/preprocess/join_data.smk
+++ b/workflow/rules/preprocess/join_data.smk
@@ -45,6 +45,8 @@ rule concat_storm_tracks:
     """
     input:
         by_sample=all_storm_tracks_by_sample
+    resources:
+        mem_mb = 48_000
     output:
         tracks_from_all_samples="{OUTPUT_DIR}/storm_tracks/{STORM_SET}/tracks.geoparquet",
     run:

--- a/workflow/scripts/preprocess/parse_IBTrACS.py
+++ b/workflow/scripts/preprocess/parse_IBTrACS.py
@@ -4,6 +4,7 @@ Parse and clean IBTrACS historic storm CSV records into geoparquet
 The output schema is a superset of the STORM synthetic track data
 """
 
+import logging
 import os
 from typing import Union
 
@@ -170,6 +171,12 @@ if __name__ == "__main__":
 
     # change geometry from 0-360 to -180-180
     df.lon = np.where(df.lon > 180, df.lon - 360, df.lon)
+
+    df["point_id"] = df.apply(lambda row: f"{row.track_id}_{row.lat}_{row.lon}", axis=1)
+    n_rows_raw = len(df)
+    logging.info(f"Collated {n_rows_raw} track points")
+    df = df.drop_duplicates(subset="point_id").drop(columns=["point_id"])
+    logging.info(f"Dropped {n_rows_raw - len(df)} track points as duplicates")
 
     # construct geometry from lat and long
     df = gpd.GeoDataFrame(

--- a/workflow/scripts/preprocess/parse_IRIS.py
+++ b/workflow/scripts/preprocess/parse_IRIS.py
@@ -6,6 +6,7 @@ Output format shares columns with IBTrACS.
 """
 
 from glob import glob
+import logging
 import os
 import re
 from typing import List
@@ -37,6 +38,8 @@ IRIS_FREQUENCY = "3H"
 
 
 if __name__ == "__main__":
+
+    logging.basicConfig(format="%(asctime)s %(process)d %(filename)s %(message)s", level=logging.INFO)
 
     csv_dir = snakemake.input.csv_dir
     parquet_path = snakemake.output.parquet
@@ -93,6 +96,12 @@ if __name__ == "__main__":
         data.append(df)
 
     df = pd.concat(data)
+
+    df["point_id"] = df.apply(lambda row: f"{row.track_id}_{row.lat}_{row.lon}", axis=1)
+    n_rows_raw = len(df)
+    logging.info(f"Collated {n_rows_raw} track points")
+    df = df.drop_duplicates(subset="point_id").drop(columns=["point_id"])
+    logging.info(f"Dropped {n_rows_raw - len(df)} track points as duplicates")
 
     # construct geometry from lat and long
     df = gpd.GeoDataFrame(


### PR DESCRIPTION
Some of the STORM tracks are duplicated (for a given year and TC number, there are duplicate timesteps). This was causing problems down the line when interpolating between discontinuities in timestep.

Changes:
- Filter any of these duplicated rows in each of the track parsers.

In the future it might be an idea to re-write the parsers as classes, inheriting from a common ancestor. I shall take the technical debt this time. :volcano: 