### PR TITLE
Fix/storm fixed global

### DIFF
--- a/config/hazard_resource_locations/storm_fixed_CMCC-CM2-VHR4.txt
+++ b/config/hazard_resource_locations/storm_fixed_CMCC-CM2-VHR4.txt
@@ -1,1 +1,1 @@
-https://data.4tu.nl/ndownloader/files/35110321
+https://data.4tu.nl/file/504c838e-2bd8-4d61-85a1-d495bdc560c3/2a3759e8-f4ad-4190-abb3-434ad5c4679b

--- a/config/hazard_resource_locations/storm_fixed_CNRM-CM6-1-HR.txt
+++ b/config/hazard_resource_locations/storm_fixed_CNRM-CM6-1-HR.txt
@@ -1,1 +1,1 @@
-https://data.4tu.nl/ndownloader/files/35110318
+https://data.4tu.nl/file/504c838e-2bd8-4d61-85a1-d495bdc560c3/c460a0c8-f918-4ede-a734-75e77e99b102

--- a/config/hazard_resource_locations/storm_fixed_EC-Earth3P-HR.txt
+++ b/config/hazard_resource_locations/storm_fixed_EC-Earth3P-HR.txt
@@ -1,1 +1,1 @@
-https://data.4tu.nl/ndownloader/files/35110312
+https://data.4tu.nl/file/504c838e-2bd8-4d61-85a1-d495bdc560c3/304d1441-bd71-47c7-8231-b20253c1cc2a

--- a/config/hazard_resource_locations/storm_fixed_HadGEM3-GC31-HM.txt
+++ b/config/hazard_resource_locations/storm_fixed_HadGEM3-GC31-HM.txt
@@ -1,1 +1,1 @@
-https://data.4tu.nl/ndownloader/files/35110309
+https://data.4tu.nl/file/504c838e-2bd8-4d61-85a1-d495bdc560c3/856f9530-56d7-489e-8005-18ae36db4804

--- a/config/hazard_resource_locations/storm_fixed_constant.txt
+++ b/config/hazard_resource_locations/storm_fixed_constant.txt
@@ -1,1 +1,1 @@
-https://data.4tu.nl/ndownloader/files/35423735
+https://data.4tu.nl/file/0ea98bdd-5772-4da8-ae97-99735e891aff/0b98c6f5-c7af-45bb-bb6e-dac53e1b8d55

--- a/workflow/tropical-cyclone/STORM.smk
+++ b/workflow/tropical-cyclone/STORM.smk
@@ -202,7 +202,7 @@ rule wrap_storm_fixed:
         temp("{OUTPUT_DIR}/input/STORM/fixed/{STORM_MODEL}/{STORM_BASIN}/STORM_FIXED_RETURN_PERIODS_{STORM_MODEL}_{STORM_BASIN}_{STORM_RP}_YR_RP.wrapped.tif")
     shell:
         """
-        gdalwarp -te -180 -60 180 60 {input} {output}
+        gdalwarp -te -179.85 -60.15 180.15 59.95 -co COMPRESS=LZW -co PREDICTOR=2 -co TILED=YES {input} {output}
         """
 
 

--- a/workflow/tropical-cyclone/STORM.smk
+++ b/workflow/tropical-cyclone/STORM.smk
@@ -230,5 +230,8 @@ rule mosaic_storm_fixed:
             -F {input.basin_tif_wp} \
             --outfile={output} \
             --calc="numpy.max((A,B,C,D,E,F),axis=0)" \
-            --NoDataValue=0
+            --NoDataValue=0 \
+            --creation-option="COMPRESS=LZW" \
+            --creation-option="PREDICTOR=2" \
+            --creation-option="TILED=YES"
         """

--- a/workflow/tropical-cyclone/STORM.smk
+++ b/workflow/tropical-cyclone/STORM.smk
@@ -235,3 +235,23 @@ rule mosaic_storm_fixed:
             --creation-option="PREDICTOR=2" \
             --creation-option="TILED=YES"
         """
+
+rule mosaic_storm_fixed_all:
+    input:
+        tiffs=expand(
+            "{{OUTPUT_DIR}}/input/STORM/fixed/{STORM_MODEL}/STORM_FIXED_RETURN_PERIODS_{STORM_MODEL}_{STORM_RP}_YR_RP.tif",
+            STORM_MODEL=[
+                "constant",
+                "CMCC-CM2-VHR4",
+                "CNRM-CM6-1-HR",
+                "EC-Earth3P-HR",
+                "HadGEM3-GC31-HM",
+            ],
+            STORM_RP=(
+                list(range(10, 100, 10))
+                + list(range(100, 1000, 100))
+                + list(range(1000, 10001, 1000))
+            ),
+        )
+    output:
+        touch("{OUTPUT_DIR}/input/STORM/fixed/mosaic.done")


### PR DESCRIPTION
The key change is to wrap STORM files to an extent aligned with the source files' pixels. This was half a pixel (0.05 degrees) out, as the source data aligns with integer degrees at the centre, not the upper-left corner, of some cells.